### PR TITLE
read_obsparam except for model-only (no DA) runs

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -66,7 +66,10 @@ class LDAS_io(object):
 
         self.paths = paths(exp=exp, domain=domain)
 
-        self.obsparam = self.read_obsparam()
+        try:
+            self.obsparam = self.read_obsparam()
+        except:
+            'No obsparam file. This is a model-only run.'
 
         tilecoord = self.read_params('tilecoord')
         tilegrids = self.read_params('tilegrids')


### PR DESCRIPTION
read_obsparam call gives an error for model-only runs because there is no obsparam file for such runs